### PR TITLE
Add option to specify CodeClasses in runLimmaAnalysis, nanostringPCA.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: NanoTube
 Type: Package
 Title: An Easy Pipeline for NanoString nCounter Data Analysis
-Version: 1.5.2
+Version: 1.7.1
 Date: 2023-03-08
 Authors@R: c(person("Caleb", "Class", email="cclass@butler.edu",
                   role = c("cre", "aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## Changes in NanoTube 1.7.1
+- The codeclass.retain option now allows runLimmaAnalysis() to be run using
+  a CodeClass/CodeClasses specified by the user, instead of automatically 
+  removing non-endogenous genes. See help(runLimmaAnalysis) for details.
+
 ## Changes in NanoTube 1.5.1
 - We're published in Bioinformatics! CITATION file updated.
 

--- a/R/nanostringPCA.R
+++ b/R/nanostringPCA.R
@@ -12,6 +12,11 @@
 #' ggplot2 is used)
 #' @param exclude.zeros Exclude genes that are not detected in all samples
 #' (default TRUE)
+#' @param codeclass.retain The CodeClasses to retain for principal components 
+#' analysis.Generally we're interested in endogenous genes, so we keep 
+#' "endogenous" only by default. Others can be included by entering a character 
+#' vector for this option. Alternatively, all targets can be retained by 
+#' setting this option to ".". 
 #' @return A list containing:
 #' \item{pca}{The PCA object}
 #' \item{plt}{The PCA plot}
@@ -35,15 +40,20 @@
 #' nanostringPCA(dat, pc1 = 3, pc2 = 4, interactive.plot = FALSE)$plt
 
 nanostringPCA <- function(ns, pc1 = 1, pc2 = 2, 
-                          interactive.plot = FALSE, exclude.zeros = TRUE) {
+                          interactive.plot = FALSE, 
+                          exclude.zeros = TRUE,
+                          codeclass.retain = "endogenous") {
   
     # Bind local variables
     PC1 <- PC2 <- group <- NULL
     
+    # Convert codeclass.retain option to format that can be used by grep.
+    codeclass.grep <- paste(codeclass.retain, collapse = "|")
+    
     if (is(ns, "list")) {
-        pca.dat <- ns$exprs[grep("endogenous", ns$dict$CodeClass, ignore.case = TRUE),]
+        pca.dat <- ns$exprs[grep(codeclass.grep, ns$dict$CodeClass, ignore.case = TRUE),]
     } else {
-        pca.dat <- exprs(ns)[grep("endogenous", fData(ns)$CodeClass, ignore.case = TRUE),]
+        pca.dat <- exprs(ns)[grep(codeclass.grep, fData(ns)$CodeClass, ignore.case = TRUE),]
     }
     
     if (exclude.zeros) pca.dat <- pca.dat[rowSums(pca.dat == 0) == 0,]

--- a/R/runLimmaAnalysis.R
+++ b/R/runLimmaAnalysis.R
@@ -14,6 +14,11 @@
 #' be one of the levels in 'groups'). Will use the first group if NULL.
 #' @param design a design matrix for Limma analysis (default NULL, will do 
 #' analysis based on provided 'group' data)
+#' @param codeclass.retain The CodeClasses to retain for Limma analysis. 
+#' Generally we're interested in endogenous genes, so we keep "endogenous" 
+#' only by default. Others can be included by entering a character vector for 
+#' this option (see limmaResults3 example). Alternatively, all targets can be 
+#' retained by setting this option to ".". 
 #' @return The fit Limma object
 #' 
 #' @examples 
@@ -42,14 +47,24 @@
 #' 
 #' # Analyze data
 #' limmaResults2 <- runLimmaAnalysis(dat, design = design)
+#' 
+#' # Run Limma analysis including endogenous *and* housekeeping genes.
+#' limmaResults3 <- runLimmaAnalysis(dat, design = design,
+#'                      codeclass.retain = c("endogenous", "housekeeping"))
 
 
 
 runLimmaAnalysis <- function(dat, groups = NULL, base.group = NULL,
-                             design = NULL) {
-
-    dat.limma <- dat[grep("endogenous", fData(dat)$CodeClass, ignore.case = TRUE),]
-    rownames(dat.limma) <- fData(dat)$Name[grep("endogenous", 
+                             design = NULL,
+                             codeclass.retain = "endogenous") {
+  
+    # Convert codeclass.retain option to format that can be used by grep.
+    codeclass.grep <- paste(codeclass.retain, collapse = "|")
+    
+    # Retain only desired CodeClass/CodeClasses.
+    dat.limma <- dat[grep(codeclass.grep, fData(dat)$CodeClass, 
+                          ignore.case = TRUE),]
+    rownames(dat.limma) <- fData(dat)$Name[grep(codeclass.grep, 
                                                 fData(dat)$CodeClass, 
                                                 ignore.case = TRUE)]
     

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ are included to enable interoperability with other Bioconductor NanoString
 data analysis packages.
 
 Many more details can be found in the vignette (vignettes/NanoTube.Rmd).
+
+If you use the NanoTube in your work, please cite:
+Class CA, Lukan CJ, Bristow CA, Do KA. "Easy NanoString nCounter data analysis
+with the NanoTube." Bioinformatics 2023; 39(1): btac762. https://doi.org/10.1093/bioinformatics/btac762

--- a/man/nanostringPCA.Rd
+++ b/man/nanostringPCA.Rd
@@ -9,7 +9,8 @@ nanostringPCA(
   pc1 = 1,
   pc2 = 2,
   interactive.plot = FALSE,
-  exclude.zeros = TRUE
+  exclude.zeros = TRUE,
+  codeclass.retain = "endogenous"
 )
 }
 \arguments{
@@ -24,6 +25,12 @@ ggplot2 is used)}
 
 \item{exclude.zeros}{Exclude genes that are not detected in all samples
 (default TRUE)}
+
+\item{codeclass.retain}{The CodeClasses to retain for principal components 
+analysis.Generally we're interested in endogenous genes, so we keep 
+"endogenous" only by default. Others can be included by entering a character 
+vector for this option. Alternatively, all targets can be retained by 
+setting this option to ".".}
 }
 \value{
 A list containing:

--- a/man/runLimmaAnalysis.Rd
+++ b/man/runLimmaAnalysis.Rd
@@ -4,7 +4,13 @@
 \alias{runLimmaAnalysis}
 \title{Conduct differential expression analysis}
 \usage{
-runLimmaAnalysis(dat, groups = NULL, base.group = NULL, design = NULL)
+runLimmaAnalysis(
+  dat,
+  groups = NULL,
+  base.group = NULL,
+  design = NULL,
+  codeclass.retain = "endogenous"
+)
 }
 \arguments{
 \item{dat}{NanoString data ExpressionSet, from processNanostringData}
@@ -17,6 +23,12 @@ be one of the levels in 'groups'). Will use the first group if NULL.}
 
 \item{design}{a design matrix for Limma analysis (default NULL, will do 
 analysis based on provided 'group' data)}
+
+\item{codeclass.retain}{The CodeClasses to retain for Limma analysis. 
+Generally we're interested in endogenous genes, so we keep "endogenous" 
+only by default. Others can be included by entering a character vector for 
+this option (see limmaResults3 example). Alternatively, all targets can be 
+retained by setting this option to ".".}
 }
 \value{
 The fit Limma object
@@ -53,4 +65,8 @@ design <- model.matrix(~group + batch)
 
 # Analyze data
 limmaResults2 <- runLimmaAnalysis(dat, design = design)
+
+# Run Limma analysis including endogenous *and* housekeeping genes.
+limmaResults3 <- runLimmaAnalysis(dat, design = design,
+                     codeclass.retain = c("endogenous", "housekeeping"))
 }


### PR DESCRIPTION
Addresses #1. Previously, only endogenous targets were retained by these two functions.  More details can be found in help(runLimmaAnalysis).